### PR TITLE
Support for alternate Elastic Container Registry repository

### DIFF
--- a/mastodon.yaml
+++ b/mastodon.yaml
@@ -59,6 +59,14 @@ Parameters:
     Description: 'Number of days to keep automated snapshots'
     Type: Number
     Default: 30
+  MastodonVersion:
+    Description: 'Version of the mastodon and mastodon-streaming packages to deploy'
+    Type: String
+    Default: 'v4.4.4'
+  ECRRegistry:
+    Description: 'The Elastic Container Registry (ECR) repo where the Mastodon Docker images reside.'
+    Type: String
+    Default: 'public.ecr.aws/h6i3a8b9'
 Resources:
   Alerting:
     Type: 'AWS::CloudFormation::Stack'
@@ -171,7 +179,7 @@ Resources:
         AlertingModule: !GetAtt 'Alerting.Outputs.StackName'
         ClientSgModule1: !GetAtt 'ClientSg.Outputs.StackName'
         ManagedPolicyArns: !Ref S3Policy
-        AppImage: 'public.ecr.aws/h6i3a8b9/mastodon:v4.4.4'
+        AppImage: !Sub '${ECRRegistry}/mastodon:${MastodonVersion}'
         AppCommand: 'bash,-c,bundle exec rails db:migrate && bundle exec rails s -p 3000'
         AppPort: '3000'
         AppEnvironment1Key: 'LOCAL_DOMAIN'
@@ -252,7 +260,7 @@ Resources:
         AlertingModule: !GetAtt 'Alerting.Outputs.StackName'
         ClientSgModule1: !GetAtt 'ClientSg.Outputs.StackName'
         ManagedPolicyArns: !Ref S3Policy
-        AppImage: 'public.ecr.aws/h6i3a8b9/mastodon-streaming:v4.4.4'
+        AppImage: !Sub '${ECRRegistry}/mastodon-streaming:${MastodonVersion}'
         AppCommand: 'bash,-c,node ./streaming/index.js'
         AppPort: '4000'
         AppEnvironment1Key: 'LOCAL_DOMAIN'
@@ -332,7 +340,7 @@ Resources:
         AlertingModule: !GetAtt 'Alerting.Outputs.StackName'
         ClientSgModule1: !GetAtt 'ClientSg.Outputs.StackName'
         ManagedPolicyArns: !Ref S3Policy
-        AppImage: 'public.ecr.aws/h6i3a8b9/mastodon:v4.4.4'
+        AppImage: !Sub '${ECRRegistry}/mastodon:${MastodonVersion}'
         AppCommand: 'bash,-c,bundle exec sidekiq'
         AppEnvironment1Key: 'LOCAL_DOMAIN'
         AppEnvironment1Value: !Ref DomainName
@@ -411,7 +419,7 @@ Resources:
         AlertingModule: !GetAtt 'Alerting.Outputs.StackName'
         ClientSgModule1: !GetAtt 'ClientSg.Outputs.StackName'
         ManagedPolicyArns: !Ref S3Policy
-        AppImage: 'public.ecr.aws/h6i3a8b9/mastodon:v4.4.4'
+        AppImage: !Sub '${ECRRegistry}/mastodon:${MastodonVersion}'
         AppCommand: 'bash,-c,RAILS_ENV=production bin/tootctl media remove && RAILS_ENV=production bin/tootctl preview_cards remove'
         AppEnvironment1Key: 'LOCAL_DOMAIN'
         AppEnvironment1Value: !Ref DomainName


### PR DESCRIPTION
Parameterized the ECR registry and Mastodon version to deploy. These changes will allow users to build and deploy alternative releases of Mastodon on AWS without being dependent on updates to the public EHR repo.