### PR TITLE
Bug fix: !Ref required to get the value of the OverrideMastodon[Streaming]ContainerImage variable

### DIFF
--- a/mastodon.yaml
+++ b/mastodon.yaml
@@ -184,7 +184,7 @@ Resources:
         AlertingModule: !GetAtt 'Alerting.Outputs.StackName'
         ClientSgModule1: !GetAtt 'ClientSg.Outputs.StackName'
         ManagedPolicyArns: !Ref S3Policy
-        AppImage: !If [HasOverrideMastodonContainerImage, OverrideMastodonContainerImage, 'public.ecr.aws/h6i3a8b9/mastodon:v4.5.2']
+        AppImage: !If [HasOverrideMastodonContainerImage, !Ref OverrideMastodonContainerImage, 'public.ecr.aws/h6i3a8b9/mastodon:v4.5.2']
         AppCommand: 'bash,-c,bundle exec rails db:migrate && bundle exec rails s -p 3000'
         AppPort: '3000'
         AppEnvironment1Key: 'LOCAL_DOMAIN'
@@ -265,7 +265,7 @@ Resources:
         AlertingModule: !GetAtt 'Alerting.Outputs.StackName'
         ClientSgModule1: !GetAtt 'ClientSg.Outputs.StackName'
         ManagedPolicyArns: !Ref S3Policy
-        AppImage: !If [HasOverrideMastodonStreamingContainerImage, OverrideMastodonStreamingContainerImage, 'public.ecr.aws/h6i3a8b9/mastodon-streaming:v4.5.2']
+        AppImage: !If [HasOverrideMastodonStreamingContainerImage, !Ref OverrideMastodonStreamingContainerImage, 'public.ecr.aws/h6i3a8b9/mastodon-streaming:v4.5.2']
         AppCommand: 'bash,-c,node ./streaming/index.js'
         AppPort: '4000'
         AppEnvironment1Key: 'LOCAL_DOMAIN'
@@ -345,7 +345,7 @@ Resources:
         AlertingModule: !GetAtt 'Alerting.Outputs.StackName'
         ClientSgModule1: !GetAtt 'ClientSg.Outputs.StackName'
         ManagedPolicyArns: !Ref S3Policy
-        AppImage: !If [HasOverrideMastodonContainerImage, OverrideMastodonContainerImage, 'public.ecr.aws/h6i3a8b9/mastodon:v4.5.2']
+        AppImage: !If [HasOverrideMastodonContainerImage, !Ref OverrideMastodonContainerImage, 'public.ecr.aws/h6i3a8b9/mastodon:v4.5.2']
         AppCommand: 'bash,-c,bundle exec sidekiq'
         AppEnvironment1Key: 'LOCAL_DOMAIN'
         AppEnvironment1Value: !Ref DomainName
@@ -424,7 +424,7 @@ Resources:
         AlertingModule: !GetAtt 'Alerting.Outputs.StackName'
         ClientSgModule1: !GetAtt 'ClientSg.Outputs.StackName'
         ManagedPolicyArns: !Ref S3Policy
-        AppImage: !If [HasOverrideMastodonContainerImage, OverrideMastodonContainerImage, 'public.ecr.aws/h6i3a8b9/mastodon:v4.5.2']
+        AppImage: !If [HasOverrideMastodonContainerImage, !Ref OverrideMastodonContainerImage, 'public.ecr.aws/h6i3a8b9/mastodon:v4.5.2']
         AppCommand: 'bash,-c,RAILS_ENV=production bin/tootctl media remove && RAILS_ENV=production bin/tootctl preview_cards remove'
         AppEnvironment1Key: 'LOCAL_DOMAIN'
         AppEnvironment1Value: !Ref DomainName


### PR DESCRIPTION
When I ran the CF template to update my Mastodon site to v4.5.3, the new version of the WebService ECS task failed to start.  I looked at the TaskDefinition JSON and saw that that the `image` property was set to `OverrideMastodonContainerImage` (literally). Fixed the issue by changing `mastodon.yaml` to use `!Ref OverrideMastodon[Streaming]ContainerImage` in the four if statements that override the Docker image URL.

Tested by deploying to montereybay.social; no issues.